### PR TITLE
recruitment#48: "supports temporary AWS credentials"

### DIFF
--- a/tests/recruitment/agency/__init__.py
+++ b/tests/recruitment/agency/__init__.py
@@ -1,4 +1,3 @@
-from actionpack.actions import RetryPolicy
 from actionpack.actions import Write
 from contextlib import contextmanager
 from datetime import datetime
@@ -20,6 +19,11 @@ fake_credentials = {
     'access_key_id': 's3curityBadge!',
     'secret_access_key': 'p@ssw0rd!',
     'endpoint_url': 'some-computer.com',
+}
+
+fake_credentials_with_session_token = {
+    **{'session_token': 'jamSesh3000!'},
+    **fake_credentials
 }
 
 write_to_deadletter_file = Write(

--- a/tests/recruitment/agency/test_config.py
+++ b/tests/recruitment/agency/test_config.py
@@ -1,11 +1,11 @@
 from os import environ as envvars
-from dataclasses import asdict
 from textwrap import dedent
 from unittest import TestCase
 from unittest.mock import patch
 
 from tests.recruitment.agency import acceptable_broker_names
 from tests.recruitment.agency import fake_credentials
+from tests.recruitment.agency import fake_credentials_with_session_token
 from recruitment.agency import Config
 
 
@@ -36,9 +36,16 @@ class ConfigTest(TestCase):
     def test_can_instantiate(self):
         for name in acceptable_broker_names:
             config = Config(name, **fake_credentials)
-            config_dict = asdict(config)
+            config_dict = dict(config)
             config_dict.pop('service_name')
             self.assertDictEqual(config_dict, fake_credentials)
+
+    def test_can_instantiate_with_session_token(self):
+        for name in acceptable_broker_names:
+            config = Config(name, **fake_credentials_with_session_token)
+            config_dict = dict(config)
+            config_dict.pop('service_name')
+            self.assertDictEqual(config_dict, fake_credentials_with_session_token)
 
     def test_can_serialize(self):
         config = Config(self.broker_name, **fake_credentials)
@@ -105,6 +112,84 @@ class ConfigTest(TestCase):
         self.assertEqual(config.access_key_id, fake_credentials['access_key_id'])
         self.assertEqual(config.secret_access_key, fake_credentials['secret_access_key'])
         self.assertEqual(config.endpoint_url, fake_credentials['endpoint_url'])
+
+    @patch.dict(
+        envvars,
+        {
+            'AWS_SERVICE_NAME': broker_name,
+            'AWS_REGION_NAME': fake_credentials_with_session_token['region_name'],
+            'AWS_ACCESS_KEY_ID': fake_credentials_with_session_token['access_key_id'],
+            'AWS_SECRET_ACCESS_KEY': fake_credentials_with_session_token['secret_access_key'],
+            'AWS_SESSION_TOKEN': fake_credentials_with_session_token['session_token'],
+            'AWS_ENDPOINT_URL': fake_credentials_with_session_token['endpoint_url'],
+        },
+        clear=True
+    )
+    def test_can_supplement_Config_instance_from_environment_with_session_token(self):
+        some_service_name = 'kinesis'
+        self.assertNotEqual(self.broker_name, some_service_name)
+        config = Config(service_name=some_service_name)
+        self.assertEqual(config.service_name, some_service_name)
+        self.assertEqual(config.region_name, None)
+        self.assertEqual(config.access_key_id, None)
+        self.assertEqual(config.secret_access_key, None)
+        self.assertEqual(config.session_token, None)
+        self.assertEqual(config.endpoint_url, None)
+        config = config.supplement('env')
+        self.assertEqual(config.service_name, some_service_name)
+        self.assertEqual(config.region_name, fake_credentials_with_session_token['region_name'])
+        self.assertEqual(config.access_key_id, fake_credentials_with_session_token['access_key_id'])
+        self.assertEqual(config.secret_access_key, fake_credentials_with_session_token['secret_access_key'])
+        self.assertEqual(config.session_token, fake_credentials_with_session_token['session_token'])
+        self.assertEqual(config.endpoint_url, fake_credentials_with_session_token['endpoint_url'])
+
+    @patch.dict(
+        envvars,
+        {
+            'AWS_SERVICE_NAME': broker_name,
+            'AWS_SESSION_TOKEN': '',
+        },
+        clear=True
+    )
+    def test_session_token_attr_absent_if_envvar_is_empty(self):
+        config = Config.fromenv()
+        with self.assertRaises(AttributeError):
+            config.session_token
+
+    @patch.dict(
+        envvars,
+        {
+            'AWS_SERVICE_NAME': broker_name,
+            'AWS_SESSION_TOKEN': fake_credentials_with_session_token['session_token'],
+        },
+        clear=True
+    )
+
+    def test_session_token_attr_present_if_envvar_has_value(self):
+        config = Config.fromenv()
+        self.assertEqual(config.session_token, fake_credentials_with_session_token['session_token'])
+
+    @patch.dict(
+        envvars,
+        {
+            'AWS_SERVICE_NAME': broker_name,
+            'AWS_REGION_NAME': fake_credentials_with_session_token['region_name'],
+            'AWS_ACCESS_KEY_ID': fake_credentials_with_session_token['access_key_id'],
+            'AWS_SECRET_ACCESS_KEY': fake_credentials_with_session_token['secret_access_key'],
+            'AWS_SESSION_TOKEN': fake_credentials_with_session_token['session_token'],
+            'AWS_ENDPOINT_URL': fake_credentials_with_session_token['endpoint_url'],
+        },
+        clear=True
+    )
+    def test___repr__(self):
+        # sensitive to env ordering
+        obj_repr = ('Config(service_name=logs, '
+                    'region_name=somewhere-in-the-world, '
+                    'access_key_id=s3curityBadge!, '
+                    'secret_access_key=p@ssw0rd!, '
+                    'endpoint_url=some-computer.com, '
+                    'session_token=jamSesh3000!)')
+        self.assertEqual(obj_repr, repr(Config.fromenv()))
 
     def test_cannot_instantiate_without_service_name(self):
         with self.assertRaises(Config.AttributeDeclaredIncorrectly):

--- a/tests/recruitment/agency/test_consumer.py
+++ b/tests/recruitment/agency/test_consumer.py
@@ -154,3 +154,14 @@ class ConsumerTest(TestCase):
         self.assertEqual(len(effort.retries), max_retries)
         for retry in effort.retries:
             self.assertIsInstance(retry.value, ClientError)
+
+    def test_Contingency_reaction_must_be_an_Action(self):
+        even_faker_credentials = {k: v for k, v in fake_credentials.items() if k != 'endpoint_url'}
+        consumer = Consumer(
+            coordinator=Coordinator(
+                commlink=Commlink(Config(self.broker, **even_faker_credentials)),
+                contingency=Contingency(reaction='NotAnActionObject')
+            )
+        )
+        with self.assertRaises(TypeError):  # reaction cannot be a str
+            consumer.consume(logGroupName='the construct', logStreamName='the-training-program')

--- a/tests/recruitment/agency/test_job.py
+++ b/tests/recruitment/agency/test_job.py
@@ -46,3 +46,4 @@ class JobTest(TestCase):
         self.assertTrue(effort.culmination.successful)
         self.assertDictEqual(effort.culmination.value, self.expected_create_target_response)
         self.assertTrue(effort.attempts)
+        self.assertEqual(repr(effort), '<Effort:succeeded>')


### PR DESCRIPTION
closes #48 

change proven to yield a successful effort given temporary credentials